### PR TITLE
add test mechanism for validation

### DIFF
--- a/src/api/apiImpl.ts
+++ b/src/api/apiImpl.ts
@@ -16,7 +16,7 @@ interface ServerApi {
 
 class DefaultServer implements ServerApi {
   private static FAILURE_PERCENT = 0.0;
-  private static SERVER_DELAY = 200;
+  private static SERVER_DELAY = 100;
 
   private readonly users: Paginator<UserData>;
   private readonly projects: Paginator<ProjectData>;

--- a/src/api/busyLoopDetector.ts
+++ b/src/api/busyLoopDetector.ts
@@ -4,7 +4,7 @@ export class BusyLoopDetector {
   private timeWindow: number;
   private startTime: number;
 
-  constructor(threshold: number = 100, timeWindow: number = 1000) {
+  constructor(threshold: number = 1000, timeWindow: number = 1000) {
     this.counter = 0;
     this.threshold = threshold;
     this.timeWindow = timeWindow;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,43 @@ import * as React from "react";
 import { render } from "react-dom";
 
 import App from "./App";
+import { PROJECTS, USERS } from "./api/data";
+import { ProjectData, SERVER, UserData } from "./api";
+import { Page } from "./api/pagination";
 
 const rootElement = document.getElementById("root");
 render(<App />, rootElement);
+
+(window as any).test = () => {
+  const testUser = async (user?: UserData) => {
+    const pageSize = 5;
+    const filterCallback = user ? (project: ProjectData) => project.creatorId === user.id : undefined;
+    const userString = user != null ? `User ${user.name} (ID: ${user.id})` : `All users`;
+    let totalCountFromApi = 0;
+    let hasMoreResults = true;
+    let lastProject: ProjectData | undefined = undefined;
+
+    while (hasMoreResults) {
+      const page: Page<ProjectData> = await SERVER.getProjects({ pageSize, startAfter: lastProject, filterCallback });
+      if (page.hasMoreResults && page.results.length < pageSize) {
+        console.log(
+          `❌ ${userString} // Improperly sized page - hasMoreResults: true but results.length < pageSize`
+        );
+        console.groupEnd();
+        return;
+      }
+      totalCountFromApi += page.results.length;
+      hasMoreResults = page.hasMoreResults;
+      lastProject = page.results[page.results.length - 1];
+    }
+
+    const totalCountFromRepo = filterCallback ? PROJECTS.filter(filterCallback).length : PROJECTS.length;
+
+    if (totalCountFromApi !== totalCountFromRepo) {
+      console.log(`❌ ${userString} // Mismatch: API count = ${totalCountFromApi}, Repo count = ${totalCountFromRepo}`);
+    } else {
+      console.log(`✅ ${userString} // Counts match: ${totalCountFromApi}`);
+    }
+  }
+  Promise.all([...USERS.map(testUser), testUser()]);
+}


### PR DESCRIPTION
New option to just run `test()` from the DevTools to roughly validate solution, rather than having candidates individually test. I think this is useful to do at the very end for completeness, and validation manually with the UX is fine otherwise. Open to thoughts though?

With no implementation:
![Screenshot 2024-07-16 at 2 13 01 PM](https://github.com/user-attachments/assets/381f6c66-3032-4c12-8efa-979651040ce7)

With correct implementation:
![Screenshot 2024-07-16 at 2 12 17 PM](https://github.com/user-attachments/assets/02df6c08-a16e-468f-81ba-979bbca4727a)

Also catches when `hasMoreResults` is true but the wrong page size is returned, such as when someone returns `filtered` and not `filtered.slice(0, pageSize)` when overfilling pages.
![Screenshot 2024-07-16 at 2 10 57 PM](https://github.com/user-attachments/assets/e2bab279-07ea-4dce-afb3-81633759763f)

